### PR TITLE
Fix python_version format

### DIFF
--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fix python_version 3.13 format

--- a/splunkattackanalyzer.json
+++ b/splunkattackanalyzer.json
@@ -7,10 +7,7 @@
     "logo": "logo_splunkattackanalyzer.svg",
     "logo_dark": "logo_splunkattackanalyzer_dark.svg",
     "product_name": "Splunk Attack Analyzer",
-    "python_version": [
-        "3.9",
-        "3.13"
-    ],
+    "python_version": "3.9, 3.13",
     "product_version_regex": ".*",
     "publisher": "Splunk",
     "license": "Copyright (c) 2023-2025 Splunk Inc.",


### PR DESCRIPTION
- Fix python_version format in app JSON files from array `["3.9", "3.13"]` to string `"3.9, 3.13"`

[_Created by Sourcegraph batch change `grokas-splunk/003-fix-python-version-format`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/003-fix-python-version-format)